### PR TITLE
Fix incorrect dimensions when loading the shift predictor

### DIFF
--- a/loading.py
+++ b/loading.py
@@ -53,10 +53,10 @@ def load_from_dir(root_dir, model_index=None, G_weights=None, shift_in_w=True):
         type=DEFORMATOR_TYPE_DICT[args['deformator']])
 
     if 'shift_predictor' not in args.keys() or args['shift_predictor'] == 'ResNet':
-        shift_predictor = LatentShiftPredictor(G.dim_shift)
+        shift_predictor = LatentShiftPredictor(args['directions_count'] if 'directions_count' in args.keys() else None)
     elif args['shift_predictor'] == 'LeNet':
         shift_predictor = LeNetShiftPredictor(
-            G.dim_shift, 1 if args['gan_type'] == 'SN_MNIST' else 3)
+            args['directions_count'] if 'directions_count' in args.keys() else None, 1 if args['gan_type'] == 'SN_MNIST' else 3)
 
     deformator_model_path = os.path.join(models_dir, 'deformator_{}.pt'.format(model_index))
     shift_model_path = os.path.join(models_dir, 'shift_predictor_{}.pt'.format(model_index))


### PR DESCRIPTION
When loading the shift predictor, its dimensions were not being loaded correctly. 

It does not match the directions of the latent deformator. For example, with a deformator of 64 dimensions, by default the shift predictor was initialized with 128 dimensions. This would not fail during training because of pytorch's use of both one-hots and integers in the cross-entropy loss of the predictor.

This small change in setting the shift predictor's dim explicitly to `directions_count` fixes this.

Correct me if my interpretation is wrong